### PR TITLE
fix: Update account number mask to limit length to 15 characters

### DIFF
--- a/src/utils/inputs.ts
+++ b/src/utils/inputs.ts
@@ -109,7 +109,7 @@ const applyAccountNumberMask = (value: string) => {
 
   value = value.replace(/\D/g, '')
 
-  if (value.length > 7) value = value.slice(0, 7) + '-' + value.slice(7, 8)
+  if (value.length > 15) value = value.slice(0, 15)
 
   return value
 }


### PR DESCRIPTION
This pull request makes a small update to the `applyAccountNumberMask` utility function. The change simplifies the logic for limiting the length of the account number and removes the insertion of a dash after the seventh character.

* Updated `applyAccountNumberMask` in `src/utils/inputs.ts` to restrict the account number to a maximum of 15 digits and removed the previous logic that inserted a dash after the seventh digit.